### PR TITLE
Phase 5: add CI workflows for book build and link checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build Book
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build book
+        run: jupyter-book build source/
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-html
+          path: source/_build/html/
+          retention-days: 7

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,32 @@
+name: Check Links
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"  # Every Monday at 08:00 UTC
+  workflow_dispatch:      # Allow manual runs
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Check links
+        run: jupyter-book build source/ --builder linkcheck
+        continue-on-error: true
+
+      - name: Upload link report
+        uses: actions/upload-artifact@v4
+        with:
+          name: linkcheck-report
+          path: source/_build/linkcheck/
+          retention-days: 30


### PR DESCRIPTION
- .github/workflows/build.yml: builds the Jupyter Book on every push and PR to main; uploads rendered HTML as an artifact for 7 days
- .github/workflows/linkcheck.yml: runs jupyter-book linkcheck weekly (Monday 08:00 UTC) and on manual dispatch; uploads the report as an artifact for 30 days

Both workflows use actions/checkout@v4 and actions/setup-python@v5 targeting Python 3.11.